### PR TITLE
Added WCS to SimpleSimulator

### DIFF
--- a/notebooks/cwfs-simulation.ipynb
+++ b/notebooks/cwfs-simulation.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "259b730d-81e9-488d-8e24-2d077c4199ca",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "This notebook simulates stars at the center of the corner wavefront sensors, then uses `ts_wep` to estimate the zernikes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32dcff05-1f60-468b-a7b9-2499cf9b5f03",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import yaml\n",
+    "from tqdm.notebook import tqdm\n",
+    "import galsim\n",
+    "import batoid\n",
+    "import wfsim\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.ticker import MaxNLocator\n",
+    "\n",
+    "from lsst.ts.wep.cwfs.Algorithm import Algorithm\n",
+    "from lsst.ts.wep.cwfs.CompensableImage import CompensableImage\n",
+    "from lsst.ts.wep.cwfs.Instrument import Instrument\n",
+    "from lsst.ts.wep.Utility import (\n",
+    "    CamType,\n",
+    "    DefocalType,\n",
+    "    getConfigDir,\n",
+    "    getModulePath\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce76e853-b98e-44fb-8711-be8c1ca4b3b8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(5772156649015328606065120900824024310421)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d3b1172-83d6-47d6-92ee-f7fef5bf1d24",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set up the fiducial telescope\n",
+    "bandpass = galsim.Bandpass(\"LSST_r.dat\", wave_type='nm')\n",
+    "fiducial_telescope = batoid.Optic.fromYaml(\"LSST_r.yaml\")\n",
+    "factory = wfsim.SSTFactory(fiducial_telescope)\n",
+    "pixel_scale = 10e-6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d422ec4-8255-4551-a564-86d330dc8aab",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Setup observation parameters.  Making ~plausible stuff up.\n",
+    "observation = {\n",
+    "    'zenith': 30 * galsim.degrees,\n",
+    "    'raw_seeing': 0.7 * galsim.arcsec,  # zenith 500nm seeing\n",
+    "    'wavelength': bandpass.effective_wavelength,\n",
+    "    'exptime': 15.0,  # seconds\n",
+    "    'temperature': 293.,  # Kelvin\n",
+    "    'pressure': 69.,  #kPa\n",
+    "    'H2O_pressure': 1.0  #kPa\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1246cdb5-57d7-4f58-bcc9-6dec4f495141",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Setup atmospheric parameters\n",
+    "atm_kwargs = {\n",
+    "    'screen_size': 819.2,\n",
+    "    'screen_scale': 0.1,\n",
+    "    'nproc': 6  # create screens in parallel using this many CPUs\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ff63cb2-21d3-47e5-a6b6-05ad5ccd71f0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# perturb the mirrors\n",
+    "dof = rng.normal(scale=0.1, size=50) # activate some M2 bending modes\n",
+    "dof[[28, 45, 46]] = 0 # but zero-out the hexafoil modes that aren't currently fit well.\n",
+    "telescope = factory.get_telescope(dof=dof)  # no perturbations yet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1026f0fe-2045-41d0-8196-41037900f2cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we simulate one (pair) of the corner wavefront sensors\n",
+    "# you set which pair by setting the raft.\n",
+    "# options are: R40 - R44\n",
+    "#               |     |\n",
+    "#              R00 - R04\n",
+    "raft = \"R00\"\n",
+    "\n",
+    "# create the extrafocal simulator, i.e. the simulator for raft_SW0\n",
+    "extra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, +0.0015])\n",
+    "extra_simulator = wfsim.SimpleSimulator(\n",
+    "    observation,\n",
+    "    atm_kwargs,\n",
+    "    extra,\n",
+    "    bandpass,\n",
+    "    name=f\"{raft}_SW0\",\n",
+    "    rng=rng\n",
+    ")\n",
+    "\n",
+    "# create the intrafocal simulator, i.e. the simulator for raft_SW1\n",
+    "intra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, -0.0015])\n",
+    "intra_simulator = wfsim.SimpleSimulator(\n",
+    "    observation,\n",
+    "    atm_kwargs,\n",
+    "    intra,\n",
+    "    bandpass,\n",
+    "    name=f\"{raft}_SW1\",\n",
+    "    rng=rng\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f75cf10-5b57-4db1-bee9-82b83dc2bec0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set the star properties\n",
+    "star_T = 8000\n",
+    "sed = wfsim.BBSED(star_T)\n",
+    "flux = 10_000_000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "129bf4b7-90d2-4adc-a6d9-1aeda20a8d75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# simulate a star at the center of the extrafocal chip\n",
+    "extra_bounds = extra_simulator.get_bounds()\n",
+    "extra_thx = extra_bounds[0].mean()\n",
+    "extra_thy = extra_bounds[1].mean()\n",
+    "extra_simulator.add_star(extra_thx, extra_thy, sed, flux, rng)\n",
+    "\n",
+    "# simulate a star at the center of the intrafocal chip\n",
+    "intra_bounds = intra_simulator.get_bounds()\n",
+    "intra_thx = intra_bounds[0].mean()\n",
+    "intra_thy = intra_bounds[1].mean()\n",
+    "intra_simulator.add_star(intra_thx, intra_thy, sed, flux, rng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35ba2184-ef49-43f7-ab7e-6dfbc8a3e8a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# add the sky background\n",
+    "extra_simulator.add_background(1000.0, rng)\n",
+    "intra_simulator.add_background(1000.0, rng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efb55e87-9121-4d2f-af0b-55f8edddb812",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# now we will plot the two chips\n",
+    "\n",
+    "# first set up the figure and axes\n",
+    "# get horizontal/vertical orientation correct\n",
+    "if raft[1] == raft[2]:\n",
+    "    fix, axes = plt.subplots(ncols=1, nrows=2, figsize=(4, 4), sharex=True, sharey=True, dpi=120)\n",
+    "else:\n",
+    "    fix, axes = plt.subplots(ncols=2, nrows=1, figsize=(4, 4), sharex=True, sharey=True, dpi=120)\n",
+    "# make sure extrafocal chip is closer to center of focal plane\n",
+    "if raft[1] == \"4\":\n",
+    "    axes = axes[::-1]\n",
+    "\n",
+    "# plot the extrafocal chip\n",
+    "axes[0].imshow(extra_simulator.image.array, origin=\"lower\")\n",
+    "axes[0].text(\n",
+    "    0.02, 0.98, \n",
+    "    f\"{extra_simulator.sensor_name}\\nextra\", \n",
+    "    transform=axes[0].transAxes, \n",
+    "    ha=\"left\", va=\"top\", \n",
+    "    c=\"w\",\n",
+    ")\n",
+    "\n",
+    "# plot the intrafocal chip\n",
+    "axes[1].imshow(intra_simulator.image.array, origin=\"lower\")\n",
+    "axes[1].text(\n",
+    "    0.02, 0.98, \n",
+    "    f\"{intra_simulator.sensor_name}\\nintra\", \n",
+    "    transform=axes[1].transAxes, \n",
+    "    ha=\"left\", va=\"top\", \n",
+    "    c=\"w\",\n",
+    ")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c59a6a72-3de7-47ee-8736-1051ebb1ed5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# now we will crop the donuts \n",
+    "\n",
+    "# first set up the figure and axes\n",
+    "# get horizontal/vertical orientation correct\n",
+    "if raft[1] == raft[2]:\n",
+    "    fix, axes = plt.subplots(ncols=1, nrows=2, figsize=(3, 6), sharex=True, sharey=True, dpi=120)\n",
+    "else:\n",
+    "    fix, axes = plt.subplots(ncols=2, nrows=1, figsize=(6, 3), sharex=True, sharey=True, dpi=120)\n",
+    "# make sure extrafocal chip is closer to center of focal plane\n",
+    "if raft[1] == \"4\":\n",
+    "    axes = axes[::-1]\n",
+    "\n",
+    "# plot the extrafocal image\n",
+    "x, y = extra_simulator.wcs.radecToxy(extra_thx, extra_thy, galsim.radians) # donut center in x/y coords\n",
+    "x = int(x - extra_simulator.image.bounds.xmin) # x in image coords\n",
+    "y = int(y - extra_simulator.image.bounds.ymin) # y in image coords\n",
+    "extra_img = extra_simulator.image.array[y-128:y+128, x-128:x+128] # cut out the donut\n",
+    "axes[0].imshow(extra_img, origin=\"lower\")\n",
+    "axes[0].text(\n",
+    "    0.02, 0.98, \n",
+    "    f\"{extra_simulator.sensor_name}\\nextra\", \n",
+    "    transform=axes[0].transAxes, \n",
+    "    ha=\"left\", va=\"top\", \n",
+    "    c=\"w\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# plot the intrafocal image\n",
+    "x, y = intra_simulator.wcs.radecToxy(intra_thx, intra_thy, galsim.radians)\n",
+    "x = int(x - intra_simulator.image.bounds.xmin) # x in image coords\n",
+    "y = int(y - intra_simulator.image.bounds.ymin) # y in image coords\n",
+    "intra_img = intra_simulator.image.array[y-128:y+128, x-128:x+128] # cut out the donut\n",
+    "axes[1].imshow(intra_img, origin=\"lower\")\n",
+    "axes[1].text(\n",
+    "    0.02, 0.98, \n",
+    "    f\"{intra_simulator.sensor_name}\\nintra\", \n",
+    "    transform=axes[1].transAxes, \n",
+    "    ha=\"left\", va=\"top\", \n",
+    "    c=\"w\",\n",
+    ")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0351bb71-0eee-4221-8141-a88005ff1c66",
+   "metadata": {},
+   "source": [
+    "Now we want to load the stuff from `ts_wep` to estimate the zernikes from the donuts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "234b57ad-d5a8-4be1-9222-1c49c6b1badf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# CWFS config\n",
+    "cwfsConfigDir = os.path.join(getConfigDir(), \"cwfs\")\n",
+    "instDir = os.path.join(cwfsConfigDir, \"instData\")\n",
+    "inst = Instrument(instDir)\n",
+    "algoDir = os.path.join(cwfsConfigDir, \"algo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20449856-6c3b-4865-b25f-491d089c72f7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# run zernike estimation using the FFT algorithm\n",
+    "I_extra = CompensableImage()\n",
+    "I_extra.setImg(np.rad2deg([extra_thx, extra_thy]), DefocalType.Extra, image=extra_img.copy())\n",
+    "\n",
+    "I_intra = CompensableImage()\n",
+    "I_intra.setImg(np.rad2deg([intra_thx, intra_thy]), DefocalType.Intra, image=intra_img.copy())\n",
+    "              \n",
+    "inst.config(CamType.LsstFamCam, I_extra.getImgSizeInPix(), announcedDefocalDisInMm=1.5)\n",
+    "\n",
+    "fftAlgo = Algorithm(algoDir)\n",
+    "fftAlgo.config(\"fft\", inst)          \n",
+    "fftAlgo.runIt(I_intra, I_extra, \"offAxis\", tol=1e-3)\n",
+    "fft_zk = fftAlgo.getZer4UpInNm()\n",
+    "\n",
+    "# run zernike estimation using the Exp algorithm\n",
+    "# There's probably a reset method somewhere, but it's fast enough to just\n",
+    "# reconstruct these...\n",
+    "I_extra = CompensableImage()\n",
+    "I_extra.setImg(np.rad2deg([extra_thx, extra_thy]), DefocalType.Extra, image=extra_img.copy())\n",
+    "\n",
+    "I_intra = CompensableImage()\n",
+    "I_intra.setImg(np.rad2deg([intra_thx, intra_thy]), DefocalType.Intra, image=intra_img.copy())\n",
+    "              \n",
+    "inst.config(CamType.LsstFamCam, I_extra.getImgSizeInPix(), announcedDefocalDisInMm=1.5)\n",
+    "\n",
+    "expAlgo = Algorithm(algoDir)\n",
+    "expAlgo.config(\"exp\", inst)          \n",
+    "expAlgo.runIt(I_intra, I_extra, \"offAxis\", tol=1e-3)\n",
+    "exp_zk = expAlgo.getZer4UpInNm()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a81a5a52-3fbc-48ad-b752-303d84e46e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the true zernikes at the center of the corner wavefront chip\n",
+    "center_thx, center_thy = np.hstack((extra_bounds, intra_bounds)).mean(axis=1)\n",
+    "bzk = batoid.zernike(telescope, center_thx, center_thy, 622e-9, eps=0.61)\n",
+    "# convert wave -> nm\n",
+    "bzk *= 622"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76a3bc60-285b-432d-a06f-0806f0a2ef3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print all the zernikes\n",
+    "for i in range(4, 23):\n",
+    "    print(f\"{i:2}  {exp_zk[i-4]:8.3f} nm  {fft_zk[i-4]:8.3f} nm  {bzk[i]:8.3f} nm\")\n",
+    "\n",
+    "fig, ax = plt.subplots(dpi=120)\n",
+    "ax.plot(range(4, 23), fft_zk, label='fft')\n",
+    "ax.plot(range(4, 23), exp_zk, label='exp')\n",
+    "ax.plot(range(4, 23), bzk[4:], label='truth')\n",
+    "plt.axhline(0, c='k')\n",
+    "\n",
+    "ax.legend()\n",
+    "\n",
+    "ax.set(xlabel=\"Noll index\", ylabel=\"Perturbation amplitude (nm)\")\n",
+    "ax.xaxis.set_major_locator(MaxNLocator(integer=True))\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ff7d159-fea2-4c65-a1c3-e1247153b75b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/ts_wep demo off-axis.ipynb
+++ b/notebooks/ts_wep demo off-axis.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c19cff08-adbd-4b46-af1b-0d4f3f169c70",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32dcff05-1f60-468b-a7b9-2499cf9b5f03",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import yaml\n",
+    "from tqdm.notebook import tqdm\n",
+    "import galsim\n",
+    "import batoid\n",
+    "import wfsim\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from lsst.ts.wep.cwfs.Algorithm import Algorithm\n",
+    "from lsst.ts.wep.cwfs.CompensableImage import CompensableImage\n",
+    "from lsst.ts.wep.cwfs.Instrument import Instrument\n",
+    "from lsst.ts.wep.Utility import (\n",
+    "    CamType,\n",
+    "    DefocalType,\n",
+    "    getConfigDir,\n",
+    "    getModulePath\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce76e853-b98e-44fb-8711-be8c1ca4b3b8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(5772156649015328606065120900824024310421)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d3b1172-83d6-47d6-92ee-f7fef5bf1d24",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "bandpass = galsim.Bandpass(\"LSST_r.dat\", wave_type='nm')\n",
+    "fiducial_telescope = batoid.Optic.fromYaml(\"LSST_r.yaml\")\n",
+    "factory = wfsim.SSTFactory(fiducial_telescope)\n",
+    "pixel_scale = 10e-6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d422ec4-8255-4551-a564-86d330dc8aab",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Setup observation parameters.  Making ~plausible stuff up.\n",
+    "observation = {\n",
+    "    'zenith': 30 * galsim.degrees,\n",
+    "    'raw_seeing': 0.7 * galsim.arcsec,  # zenith 500nm seeing\n",
+    "    'wavelength': bandpass.effective_wavelength,\n",
+    "    'exptime': 15.0,  # seconds\n",
+    "    'temperature': 293.,  # Kelvin\n",
+    "    'pressure': 69.,  #kPa\n",
+    "    'H2O_pressure': 1.0  #kPa\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1246cdb5-57d7-4f58-bcc9-6dec4f495141",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Setup atmospheric parameters\n",
+    "atm_kwargs = {\n",
+    "    'screen_size': 819.2,\n",
+    "    'screen_scale': 0.1,\n",
+    "    'nproc': 6  # create screens in parallel using this many CPUs\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ff63cb2-21d3-47e5-a6b6-05ad5ccd71f0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dof = np.zeros(50)\n",
+    "# dof[40:44] = 0.2  # activate some M2 bending modes\n",
+    "dof = rng.normal(scale=0.1, size=50)\n",
+    "# but zero-out the hexafoil modes that aren't currently fit well.\n",
+    "dof[[28, 45, 46]] = 0\n",
+    "telescope = factory.get_telescope(dof=dof)  # no perturbations yet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9be07033-dba0-4db7-8b7b-fd23c252a05b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Look at some spot diagrams\n",
+    "fig, axes = plt.subplots(nrows=1, ncols=5, figsize=(8, 1.5))\n",
+    "for ax, (thx, thy) in zip(axes, [(0,0), (-1.5, 0), (1.5, 0), (0, -1.5), (0, 1.5)]):\n",
+    "    sx, sy = batoid.spot(\n",
+    "        telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, 0.0015]), \n",
+    "        np.deg2rad(thx), np.deg2rad(thy), \n",
+    "        bandpass.effective_wavelength*1e-9, \n",
+    "        nx=128\n",
+    "    )\n",
+    "    ax.scatter(sx/pixel_scale, sy/pixel_scale, s=0.1, alpha=0.5)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68df6626-4fb8-4878-8fe4-16b151ea99d9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Execute this line if you want to reconstruct the atmosphere below.\n",
+    "if 'intra_simulator' in globals():\n",
+    "    del intra_simulator, extra_simulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1026f0fe-2045-41d0-8196-41037900f2cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# BEWARE THE HACK!!!\n",
+    "# HACK EXISTS TO NOT RECOMPUTE ATMOSPHERE ALL THE TIME!!!\n",
+    "if 'intra_simulator' not in globals():\n",
+    "    intra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, -0.0015])\n",
+    "    extra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, +0.0015])\n",
+    "    intra_simulator = wfsim.SimpleSimulator(\n",
+    "        observation,\n",
+    "        atm_kwargs,\n",
+    "        intra,\n",
+    "        bandpass,\n",
+    "        # shape=(4000, 4000),\n",
+    "        # shape=(256, 256),\n",
+    "        # offset=(0.2, 0.2),\n",
+    "        name=\"R00_SW0\",\n",
+    "        rng=rng\n",
+    "    )\n",
+    "    extra_simulator = wfsim.SimpleSimulator(\n",
+    "        observation,\n",
+    "        atm_kwargs,\n",
+    "        extra,\n",
+    "        bandpass,\n",
+    "        # shape=(4000, 4000),\n",
+    "        # offset=(0.2, 0.2),\n",
+    "        name=\"R00_SW0\",\n",
+    "        rng=rng\n",
+    "    )\n",
+    "else:\n",
+    "    intra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, -0.0015])\n",
+    "    extra = telescope.withGloballyShiftedOptic(\"Detector\", [0, 0, +0.0015])\n",
+    "    intra_simulator.telescope = intra\n",
+    "    extra_simulator.telescope = extra\n",
+    "    intra_simulator.image.setZero()\n",
+    "    extra_simulator.image.setZero()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f75cf10-5b57-4db1-bee9-82b83dc2bec0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "star_T = rng.uniform(4000, 10000)\n",
+    "sed = wfsim.BBSED(star_T)\n",
+    "# flux = int(rng.uniform(1_000_000, 2_000_000))\n",
+    "flux = 10_000_000\n",
+    "# flux = 500_000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "019ae86f-4259-4d0c-959f-6a22dd63d17e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lets print the bounds of the sensors so we know what angles to simulate\n",
+    "bounds = intra_simulator.get_bounds(units=galsim.degrees)\n",
+    "print(f\"{bounds[0, 0]:.3f} < x < {bounds[0, 1]:.3f}\")\n",
+    "print(f\"{bounds[1, 0]:.3f} < y < {bounds[1, 1]:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52dc98bc-ba02-419a-b4ca-cf5dcaaae027",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "thx = np.deg2rad(-1.12)\n",
+    "thy = np.deg2rad(-1.12)\n",
+    "# thx = np.deg2rad(0.0)\n",
+    "# thy = np.deg2rad(0.0)\n",
+    "intra_simulator.add_star(thx, thy, sed, flux, rng)\n",
+    "extra_simulator.add_star(thx, thy, sed, flux, rng)\n",
+    "# intra_simulator.add_star(0.0, 0.0, sed, flux, rng)\n",
+    "# extra_simulator.add_star(0.0, 0.0, sed, flux, rng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35ba2184-ef49-43f7-ab7e-6dfbc8a3e8a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "intra_simulator.add_background(1000.0, rng)\n",
+    "extra_simulator.add_background(1000.0, rng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efb55e87-9121-4d2f-af0b-55f8edddb812",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fix, axes = plt.subplots(ncols=2, nrows=1, figsize=(6, 3), sharex=True, sharey=True)\n",
+    "axes[0].imshow(intra_simulator.image.array, origin=\"lower\")\n",
+    "axes[1].imshow(extra_simulator.image.array, origin=\"lower\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c59a6a72-3de7-47ee-8736-1051ebb1ed5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# crop the donuts and to feed to CWFS\n",
+    "\n",
+    "# intra image\n",
+    "x, y = intra_simulator.wcs.radecToxy(thx, thy, galsim.radians)\n",
+    "x = int(x - intra_simulator.image.bounds.xmin)\n",
+    "y = int(y - intra_simulator.image.bounds.ymin)\n",
+    "intra_img = intra_simulator.image.array[y-128:y+128, x-128:x+128]\n",
+    "\n",
+    "# extra image\n",
+    "x, y = extra_simulator.wcs.radecToxy(thx, thy, galsim.radians)\n",
+    "x = int(x - extra_simulator.image.bounds.xmin)\n",
+    "y = int(y - extra_simulator.image.bounds.ymin)\n",
+    "extra_img = extra_simulator.image.array[y-128:y+128, x-128:x+128]\n",
+    "\n",
+    "fix, axes = plt.subplots(ncols=2, nrows=1, figsize=(6, 3), sharex=True, sharey=True)\n",
+    "axes[0].imshow(intra_img)\n",
+    "axes[1].imshow(extra_img)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "234b57ad-d5a8-4be1-9222-1c49c6b1badf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# CWFS\n",
+    "cwfsConfigDir = os.path.join(getConfigDir(), \"cwfs\")\n",
+    "instDir = os.path.join(cwfsConfigDir, \"instData\")\n",
+    "inst = Instrument(instDir)\n",
+    "algoDir = os.path.join(cwfsConfigDir, \"algo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20449856-6c3b-4865-b25f-491d089c72f7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fieldXY = np.array([np.rad2deg(thx), np.rad2deg(thy)])\n",
+    "I1 = CompensableImage()\n",
+    "I2 = CompensableImage()\n",
+    "I1.setImg(fieldXY, DefocalType.Intra, image=intra_img.copy())\n",
+    "I2.setImg(fieldXY, DefocalType.Extra, image=extra_img.copy())\n",
+    "inst.config(CamType.LsstFamCam, I1.getImgSizeInPix(), announcedDefocalDisInMm=1.5)\n",
+    "\n",
+    "fftAlgo = Algorithm(algoDir)\n",
+    "fftAlgo.config(\"fft\", inst)\n",
+    "fftAlgo.runIt(I1, I2, \"offAxis\", tol=1e-3)\n",
+    "\n",
+    "# There's probably a reset method somewhere, but it's fast enough to just\n",
+    "# reconstruct these...\n",
+    "I1 = CompensableImage()\n",
+    "I2 = CompensableImage()\n",
+    "I1.setImg(fieldXY, DefocalType.Intra, image=intra_img.copy())\n",
+    "I2.setImg(fieldXY, DefocalType.Extra, image=extra_img.copy())\n",
+    "inst.config(CamType.LsstFamCam, I1.getImgSizeInPix(), announcedDefocalDisInMm=1.5)\n",
+    "\n",
+    "expAlgo = Algorithm(algoDir)\n",
+    "expAlgo.config(\"exp\", inst)\n",
+    "expAlgo.runIt(I1, I2, \"offAxis\", tol=1e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df750e1e-b5ca-4b56-8701-48be4df49257",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from matplotlib.ticker import MaxNLocator\n",
+    "\n",
+    "fft_zk = fftAlgo.getZer4UpInNm()\n",
+    "exp_zk = expAlgo.getZer4UpInNm()\n",
+    "bzk = batoid.zernike(telescope, 0, 0, 622e-9, eps=0.61)*622\n",
+    "for i in range(4, 23):\n",
+    "    print(f\"{i:2}  {exp_zk[i-4]:8.3f} nm  {fft_zk[i-4]:8.3f} nm  {bzk[i]:8.3f} nm\")\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(range(4, 23), fft_zk, label='fft')\n",
+    "plt.plot(range(4, 23), exp_zk, label='exp')\n",
+    "plt.plot(range(4, 23), bzk[4:], label='truth')\n",
+    "plt.legend()\n",
+    "plt.xlabel(\"Noll index\")\n",
+    "plt.ylabel(\"Perturbation amplitude (nm)\")\n",
+    "plt.axhline(0, c='k')\n",
+    "plt.gca().xaxis.set_major_locator(MaxNLocator(integer=True))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b39c56bc-42eb-4f7f-b0e0-7dc8d196a0d7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "wf = fftAlgo.getWavefrontMapEsti()\n",
+    "plt.figure()\n",
+    "plt.imshow(wf)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e881425c-e530-434f-aece-6e72c45cdf63",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I added a WCS to `SimpleSimulator`. This is accomplished on instantiation by shooting 25 photons on a grid across the focal plane and fitting using [`galsim.FittedSIPWCS`](https://galsim-developers.github.io/GalSim/_build/html/wcs.html#galsim.FittedSIPWCS).

I save the WCS under `simulator.wcs`, which allows you to do any of the WCS things you would like to do.

I also added a method `get_bounds` which will return the bounds on the field angles that hit the simulated sensor. You can change the unit of these angles, but the default is radians, as `add_star` expects field angles in radians.